### PR TITLE
set wrt unlock bit in bootloader mode

### DIFF
--- a/CANIO.asm
+++ b/CANIO.asm
@@ -541,7 +541,7 @@ _CANInit:
 #endif
     
 button_pressed:
-    
+    bsf     MODE_WRT_UNLCK          ; allow _StartWrite to succeed
     banksel EECON1
     
     ; If button is pressed we always use nickname 0xfe 


### PR DESCRIPTION
this fixes a non-initialized data bug, causing the bootloader to misbehave sometimes at startup